### PR TITLE
Install deps in the root conda env

### DIFF
--- a/r-python-eds-lessons/Dockerfile
+++ b/r-python-eds-lessons/Dockerfile
@@ -1,19 +1,12 @@
 FROM continuumio/anaconda3
 
-RUN conda update -n base -c defaults conda
-
-RUN conda config --add channels conda-forge
-
 COPY environment.yml environment.yml
 
-# RUN [ -e environment.yml ] && conda env update --quiet -f environment.yml
+RUN conda update -n base -c defaults conda
 
-RUN conda env create -f environment.yml
+RUN conda env update -n root -f environment.yml
 
-RUN echo "source activate eds-lessons" > ~/.bashrc
-ENV PATH /opt/conda/envs/env/bin:$PATH
-
-# RUN conda list
+RUN conda list
 
 RUN conda clean -tipsy
 

--- a/r-python-eds-lessons/environment.yml
+++ b/r-python-eds-lessons/environment.yml
@@ -7,8 +7,10 @@ dependencies:
   # Core scientific python
   - numpy
   - matplotlib
+  - pip
   - python=3.6
   - pyqt
+  - scikit-learn
   - seaborn
 
   # extentions
@@ -20,6 +22,7 @@ dependencies:
   - cartopy
   - geopandas
   - rasterio
+  - libiconv
   - contextily
   - pysal
   - pyproj
@@ -46,12 +49,11 @@ dependencies:
       # - download
       # - nbgrader
       - nbclean
-      - mne
+      # - mne
       # - tqdm
-      - kiwisolver
+      # - kiwisolver
       # more ea stuff
       - mapboxgl
-      - sklearn
       - hydrofunctions
       # tutorials
       - cenpy

--- a/r-python-eds-lessons/import_check.py
+++ b/r-python-eds-lessons/import_check.py
@@ -5,7 +5,6 @@ import folium
 
 # pip installaed libraries
 import nbclean
-import mne
 import kiwisolver
 import mapboxgl
 import hydrofunctions


### PR DESCRIPTION
This PR also removes the `mne` and `kiwisolver` libraries, as these (as far as I can tell) are not used in any lessons or tutorials. 